### PR TITLE
removing the favicon link and service worker.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -6,24 +6,10 @@
   <title>Stencil Component Starter</title>
   <script src="/build/myname.js"></script>
 
-  <link rel="icon" type="image/x-icon" href="/assets/icon/favicon.ico">
-
 </head>
 <body>
 
   <my-name first="Stencil" last="JS"></my-name>
-
-
-  <script>
-    if ('serviceWorker' in navigator) {
-      // auto-unregister service worker during dev mode
-      navigator.serviceWorker.ready.then(registration => {
-        registration.unregister().then(() => {
-          location.reload(true);
-        });
-      });
-    }
-  </script>
 
 </body>
 </html>


### PR DESCRIPTION
as described in issue #3, there's no assets folder since we're not targeting a html page generation.