### PR TITLE
Fix for https://github.com/ionic-team/stencil-component-starter/issue…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Stencil Component Starter",
   "main": "dist/mycomponent.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
     "dist/"


### PR DESCRIPTION
Fixes 

```
[ ERROR ]  package.json error
           package.json "types" file does not exist:
           C:\Users\connexo\sites\test\dist\types\index.d.ts
```

error on Windows 7 as raised here https://github.com/ionic-team/stencil-component-starter/issues/47