### PR TITLE
fix(): Add a www directory to prevet directory not found on first build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 dist/
-www/
 
 *~
 *.sw[mnpcod]


### PR DESCRIPTION
Same as https://github.com/ionic-team/stencil-app-starter/commit/5391c0f79d2c58d456bfed96cde4e1b91e35c74c