### PR TITLE
chore(): Change readme to use the new create-stencil tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,18 +16,18 @@ Stencil components are just Web Components, so they work in any major framework 
 
 ## Getting Started
 
-To start building a new web component using Stencil, clone this repo to a new directory:
+Start building a new web component using Stencil is so easy, thanks to the new [create-stencil](https://github.com/ionic-team/create-stencil) tool.
+
+Just execute the following command:
 
 ```bash
-git clone https://github.com/ionic-team/stencil-component-starter.git my-component
-cd my-component
-rm -rf .git
+npm init stencil components <projectName>
 ```
+and you are ready to start.
 
-and run:
+To view your new component, open the component directory and run
 
 ```bash
-npm install
 npm start
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ To start building a new web component using Stencil, clone this repo to a new di
 ```bash
 git clone https://github.com/ionic-team/stencil-component-starter.git my-component
 cd my-component
-git remote rm origin
+rm -rf .git
 ```
 
 and run:


### PR DESCRIPTION
If merged, we should do the same in stencil-app-starter.

I could do it, if you want.