### PR TITLE
fix(unit tests): missing function tested on component

### DIFF
--- a/src/components/my-component/my-component.spec.ts
+++ b/src/components/my-component/my-component.spec.ts
@@ -8,20 +8,20 @@ describe('my-component', () => {
   describe('formatting', () => {
     it('returns empty string for no names defined', () => {
       const component = new MyComponent();
-      expect(component.format()).toEqual('');
+      expect(component.getText()).toEqual('');
     });
 
     it('formats just first names', () => {
       const component = new MyComponent();
       component.first = 'Joseph';
-      expect(component.format()).toEqual('Joseph');
+      expect(component.getText()).toEqual('Joseph');
     });
 
     it('formats first and last names', () => {
       const component = new MyComponent();
       component.first = 'Joseph';
       component.last = 'Publique';
-      expect(component.format()).toEqual('Joseph Publique');
+      expect(component.getText()).toEqual('Joseph Publique');
     });
 
     it('formats first, middle and last names', () => {
@@ -29,7 +29,7 @@ describe('my-component', () => {
       component.first = 'Joseph';
       component.middle = 'Quincy';
       component.last = 'Publique';
-      expect(component.format()).toEqual('Joseph Quincy Publique');
+      expect(component.getText()).toEqual('Joseph Quincy Publique');
     });
   });
 });

--- a/src/components/my-component/my-component.tsx
+++ b/src/components/my-component/my-component.tsx
@@ -22,7 +22,7 @@ export class MyComponent {
    */
   @Prop() last: string;
 
-  private getText(): string {
+  public getText(): string {
     return format(this.first, this.middle, this.last);
   }
 


### PR DESCRIPTION
Relates to issue: [https://github.com/ionic-team/stencil-component-starter/issues/65](https://github.com/ionic-team/stencil-component-starter/issues/65)

* Replaced the default unit tests component method (format) with (getText).
* Replaced the access level for (getText) from private to public, as to allow it's use in the unit tests.