### PR TITLE
fix: deprecated type for docs generation

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -2,9 +2,9 @@ import { Config } from '@stencil/core';
 
 export const config: Config = {
   namespace: 'mycomponent',
-  outputTargets:[
+  outputTargets: [
     { type: 'dist' },
-    { type: 'docs' },
+    { type: 'docs-readme' },
     {
       type: 'www',
       serviceWorker: null // disable service workers


### PR DESCRIPTION
Changed `outputTargets` type for docs from `{ type: 'docs' }` to `{ type: 'docs-readme' }`.