### PR TITLE
Resolution to issue 1574 -- "no loader inside dist"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/stencil-starter-project-name/stencil-starter-project-name.js",
   "files": [
-    "dist/",
-    "loader/"
+    "dist/"
   ],
   "scripts": {
     "build": "stencil build --docs",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -4,8 +4,7 @@ export const config: Config = {
   namespace: 'stencil-starter-project-name',
   outputTargets: [
     {
-      type: 'dist',
-      esmLoaderPath: '../loader'
+      type: 'dist'
     },
     {
       type: 'docs-readme'


### PR DESCRIPTION
The issue 
```
The is no `loader` folder inside the `dist` folder. 
Can NOT use Stencil components inside an Ionic project.
```
https://github.com/ionic-team/stencil/issues/1574

seems to be because stencil-component-started adds two lines. 

I removed them, which fixes the issue as per the cited discussion thread.
