### PR TITLE
Correct the types file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.mjs",
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/stencil-starter-project-name/stencil-starter-project-name.js",


### PR DESCRIPTION
Leaving it as `index.d.ts` causes stencil.core.d.ts not being generated with a fresh `stencil build` (run `stencil build` again will generate stencil.core.d.ts file though), because it's checking if index.d.ts file exists, but it really should be checking if components.d.ts file exists.