### PR TITLE
fix(tsconfig.json): required for dist/types/stencil.core.d.ts to form…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,26 @@
 {
   "compilerOptions": {
+    "strict": false,
+    "alwaysStrict": true,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "declaration": false,
+    "declaration": true,
     "experimentalDecorators": true,
-    "lib": [
-      "dom",
-      "es2017"
-    ],
-    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "jsxFactory": "h",
+    "lib": ["dom", "es2017"],
     "module": "esnext",
-    "target": "es2017",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "jsx": "react",
-    "jsxFactory": "h"
+    "outDir": ".tmp",
+    "pretty": true,
+    "removeComments": false,
+    "target": "es2017"
   },
-  "include": [
-    "src",
-    "types/jsx.d.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "stencil.config.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
… on build

Currently `npm run build` does not generate `dist/types/stencil.core.d.ts`. When wrapping a Stencil component library with React, this file is needed to avoid `tsc` compilation errors. Please see a related PR which will be made soon here: https://github.com/ionic-team/stencil-ds-react-template