### PR TITLE
chore(): Make @stencil/core a devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test.watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate"
   },
-  "dependencies": {
+  "devDependencies": {
     "@stencil/core": "^2.0.1"
   },
   "license": "MIT"


### PR DESCRIPTION
@stencil/core is a dev dependency as it didn't must be installed when installed your package.