### PR TITLE
stencil.assetsRoot property proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/stencil-starter-project-name/stencil-starter-project-name.esm.js",
+  "stencil": {
+    "assetsRoot": "dist/stencil-starter-project-name/assets"
+  },
   "files": [
     "dist/",
     "loader/"


### PR DESCRIPTION
The `stencil.assetsRoot` property is supposed to standardize the way of working with the assets and make integrations of libraries easier for the users of libraries. For now, there are a lot of discussions going on around this topic. I've also encountered this issue of integration lib's assets with the app, and have come up with a feeling that it would have been so much easier, if it was standardized more strictly, so that any standardized JSON file (in this case package.json) would contain a pointer to the assets root.

It's supposed to be something, that maintainers edit, so they can go with basically any other name for the folder other than `assets`.