### PR TITLE
fix(): add module script type to README examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,12 +61,12 @@ The first step for all three of these strategies is to [publish to NPM](https://
 
 ### Script tag
 
-- Put a script tag similar to this `<script src='https://unpkg.com/my-component@0.0.1/dist/my-component.esm.js'></script>` in the head of your index.html
+- Put a script tag similar to this `<script type='module' src='https://unpkg.com/my-component@0.0.1/dist/my-component.esm.js'></script>` in the head of your index.html
 - Then you can use the element anywhere in your template, JSX, html etc
 
 ### Node Modules
 - Run `npm install my-component --save`
-- Put a script tag similar to this `<script src='node_modules/my-component/dist/my-component.esm.js'></script>` in the head of your index.html
+- Put a script tag similar to this `<script type='module' src='node_modules/my-component/dist/my-component.esm.js'></script>` in the head of your index.html
 - Then you can use the element anywhere in your template, JSX, html etc
 
 ### In a stencil-starter app


### PR DESCRIPTION
This makes it so the browser knows to load them as modules. Otherwise, the browser throws an "Uncaught SyntaxError: Cannot use import statement outside a module" error when loading the esm.js via <script> tag.

---

I've been setting up a design system and noticed that the `<script>` tag suggestion from the README wasn't working, so this updates the docs so that it works.

This did the trick for me in Chrome, but I may be missing some key elements to this.

I've got this in my code for it to work:

```
<script type="module"
    src="https://unpkg.com/breezy-components@0.1.0/dist/breezy-components/breezy-components.esm.js">
</script>
```

[Package on npm](https://www.npmjs.com/package/breezy-components), [source on GitHub](https://github.com/brettchalupa/breezy-components)