### PR TITLE
Add Jest dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "jest": "^26.6.3",
-    "puppeteer": "~10.0.0"
+    "puppeteer": "^5.5.0",
+    "@types/puppeteer": "^5.4.3"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "dependencies": {
     "@stencil/core": "^2.0.1"
   },
+  "devDependencies": {
+    "jest": "^27.0.6"
+  },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "@types/puppeteer": "^5.4.4",
-    "jest": "^27.0.6"
+    "jest": "^27.0.6",
+    "puppeteer": "~10.0.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
-    "@types/puppeteer": "^5.4.4",
     "jest": "^27.0.6",
     "puppeteer": "~10.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
-    "jest": "^27.0.6",
+    "jest": "^26.6.3",
     "puppeteer": "~10.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "jest": "^26.6.3",
+    "jest-cli": "^26.6.3",
     "puppeteer": "^5.5.0",
     "@types/puppeteer": "^5.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@stencil/core": "^2.0.1"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.24",
+    "@types/puppeteer": "^5.4.4",
     "jest": "^27.0.6"
   },
   "license": "MIT"


### PR DESCRIPTION
Related: https://github.com/ionic-team/stencil/pull/2863#issuecomment-874716268

Also adding puppeteer since it is required as well. `@types/puppeteer` is not required for the current version of puppeteer.