### PR TITLE
chore(v3): update starter for v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@stencil/core": "^3.0.0-rc.0"
+    "@stencil/core": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,14 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@stencil/core": "^2.13.0"
+    "@stencil/core": "^3.0.0-rc.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.0.3",
-    "jest": "^27.4.5",
-    "jest-cli": "^27.4.5",
-    "puppeteer": "^10.0.0"
+    "@types/jest": "^27.5.2",
+    "@types/node": "^16.18.11",
+    "jest": "^27.5.1",
+    "jest-cli": "^27.5.1",
+    "puppeteer": "^19.5.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
# What Does This Do?

## Commit 1
this commit updates the dependencies of the stencil component starter
template in preparation for the the v3.0.0 release of stencil.

the dependency on stencil is bumped to a pre-release version of the
library, and puppeteer is bumped to v19, which is now supported by
stencil v3.

jest dependencies have also been bumped, although that was done during
the course of other package updates (and is not strictly necessary for
this effort).

## Commit 2
bumps the version for stencil to use the actual release (which has not occurred yet)

# Testing

Check out this branch, and `revert` the second commit (as it uses the official Stencil 3
release version, which hasn't been published to npm). From there, you should be able to
run typical commands you would expect of a starter:
- `npm run build`
- `npm start`
- `npm run generate`
- `npm t`