### PR TITLE
chore(deps): upgrade puppeteer to v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^16.18.11",
     "jest": "^27.5.1",
     "jest-cli": "^27.5.1",
-    "puppeteer": "^19.5.2"
+    "puppeteer": "^20.7.1"
   },
   "license": "MIT"
 }

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -18,4 +18,7 @@ export const config: Config = {
       serviceWorker: null, // disable service workers
     },
   ],
+  testing: {
+    browserHeadless: "new",
+  },
 };


### PR DESCRIPTION
This upgrades puppeteer to v20 and updates the Stencil config to include an appropriate value for the `testing.browserHeadless` value.

For testing, I ran

```sh
npm t -- --no-cache
```

locally and things seem to be working correctly

