### PR TITLE
chore(deps): bump @stencil/core dependency to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@stencil/core": "^3.0.0"
+    "@stencil/core": "^4.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",


### PR DESCRIPTION
Tested out locally with [4.0.0-rc.0](https://www.npmjs.com/package/@stencil/core/v/4.0.0-rc.0) and tests, etc seem to be working fine!