### PR TITLE
chore(deps): install puppeteer 21 by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^16.18.11",
     "jest": "^27.5.1",
     "jest-cli": "^27.5.1",
-    "puppeteer": "^20.7.3"
+    "puppeteer": "^21.0.3"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
this commit bumps the default version of puppeteer from v20 to v21 for all new projects

## Testing

- checkout this branch
- `npm i && npm t`