### PR TITLE
fix(puppeteer): temporarily pin puppeteer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^16.18.11",
     "jest": "^27.5.1",
     "jest-cli": "^27.5.1",
-    "puppeteer": "^21.0.3"
+    "puppeteer": "21.1.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
with this commit, we pin puppeteer to v21.1.1. we began to observe that our CI pipeline in Stencil core began to fail due to type errors like the following:

```
[ ERROR ]  TypeScript: node_modules/puppeteer/lib/types.d.ts:345:15
           Property 'asyncDispose' does not exist on type 'SymbolConstructor'.

    L344:      [Symbol_2.dispose](): void;
    L345:      [Symbol_2.asyncDispose](): Promise<void>;
    L346:  }
```

this occurred immediately following the puppeteer v21.2 release. 

we've confirmed that 21.1.1 still works. while we works out a minimal repro case, we pin the version here to prevent folks from not being able to build