### PR TITLE
chore(scripts): remove --docs from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "loader/"
   ],
   "scripts": {
-    "build": "stencil build --docs",
+    "build": "stencil build",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",


### PR DESCRIPTION
remove the --docs flag from the npm build script. we're removing this as it's tripped a few people up as to how docs are getting generated when they remove `docs-readme` from the `stencil-config.ts` file, and still see documentation generated as a result of this flag.

`docs-readme` already exists in the output targets of `stencil-config.ts`, which results in no output changes for the boilerplate project