### PR TITLE
chore(deps): unpin puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^16.18.11",
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",
-    "puppeteer": "21.1.1"
+    "puppeteer": "^21.9.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
# Changes

in 5fba47d017f5c3678d85d73da9e66b7ab0b9049c (#124), we pinned the project's dependency on puppeteer due to failing stencil ci steps when we ran the component-starter smoke tests. this issue wasn't strictly related to ci - end users would have seen this as well (ci was an early alert for us).

since then, the typing issue here appears to have cleared itself up. unpin the dependency and update the version of puppeteer.

by applying this patch, users will:
1. get the latest version of puppeteer regardless of when they run `npm init stencil@latest component`
2. no longer see a warning in their console that their version of puppeteer is no longer supported

# Testing
I ran through effectively what we do today in the Stencil component starter smoke tests in Stencil's CI pipeline - build and test the project. Tested with Node 16 + 20 (it shouldn't make a difference since this is a TypeScript error, but better safe than sorry).

Formally, check out this branch and run `npm install && npm run build && npm t -- --no-build`.

Everything should pass, and you should _not_ see the following warning folks see today on `npm i`:
```
npm i
npm WARN deprecated puppeteer@21.1.1: < 21.5.0 is no longer supported

added 2 packages, removed 2 packages, changed 8 packages, and audited 362 packages in 3s

38 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```