### PR TITLE
chore(starter-project): Avoid confusions on distribution approaches

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018
+Copyright (c) 2024
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024
+Copyright (c) 2018
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
-  "es2015": "dist/esm/index.js",
-  "es2017": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,16 @@
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/stencil-starter-project-name/stencil-starter-project-name.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/stencil-starter-project-name/stencil-starter-project-name.esm.js",
+      "require": "./dist/stencil-starter-project-name/stencil-starter-project-name.cjs.js"
+    },
+    "./my-component": {
+      "import": "./dist/components/my-component.js",
+      "types": "./dist/components/my-component.d.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ionic-team/stencil-component-starter.git"

--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
     "test.watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate"
   },
-  "dependencies": {
-    "@stencil/core": "^4.7.0"
-  },
   "devDependencies": {
+    "@stencil/core": "^4.7.0",
     "@types/jest": "^29.5.6",
     "@types/node": "^16.18.11",
     "jest": "^29.7.0",

--- a/readme.md
+++ b/readme.md
@@ -93,8 +93,7 @@ To export Stencil components as standalone components make sure you have the [`d
 For example, given you'd like to use `<my-component />` as part of a React component, you can import the component directly via:
 
 ```tsx
-import { defineCustomElement } from 'foobar-design-system/dist/components/my-component.js';
-defineCustomElement();
+import 'foobar-design-system/dist/components/my-component.js';
 
 function App() {
   return (
@@ -112,4 +111,4 @@ function App() {
 export default App;
 ```
 
-Check out this [Live Demo](https://stackblitz.com/edit/vitejs-vite-b6zuds?file=src%2FApp.tsx).
+Check out this [Live Demo](https://stackblitz.com/edit/vitejs-vite-b6zuds?file=src%2FApp.tsx). You can shorten the import path by providing a custom `exports` map in your `package.json`.

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Check out this [Live Demo](https://stackblitz.com/edit/vitejs-vite-y6v26a?file=s
 
 ### Standalone
 
-If you are using Stencil components as part of a separate compiler that handles bundling and tree-shaking for you, we recommend importing Stencil components individually in those files where they are needed.
+If you are using a Stencil component library with `dist-custom-elements`, we recommend importing Stencil components individually in those files where they are needed.
 
 To export Stencil components as standalone components make sure you have the [`dist-custom-elements`](https://stenciljs.com/docs/custom-elements) output target defined in your `stencil.config.ts`.
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Stencil is also great for building entire apps. For that, use the [stencil-app-s
 
 Stencil is a compiler for building fast web apps using Web Components.
 
-Stencil combines the best concepts of the most popular frontend frameworks into a compile-time rather than run-time tool.  Stencil takes TypeScript, JSX, a tiny virtual DOM layer, efficient one-way data binding, an asynchronous rendering pipeline (similar to React Fiber), and lazy-loading out of the box, and generates 100% standards-based Web Components that run in any browser supporting the Custom Elements v1 spec.
+Stencil combines the best concepts of the most popular frontend frameworks into a compile-time rather than runtime tool. Stencil takes TypeScript, JSX, a tiny virtual DOM layer, efficient one-way data binding, an asynchronous rendering pipeline (similar to React Fiber), and lazy-loading out of the box, and generates 100% standards-based Web Components that run in any browser supporting the Custom Elements v1 spec.
 
 Stencil components are just Web Components, so they work in any major framework or with no framework at all.
 
@@ -45,31 +45,71 @@ npm test
 
 Need help? Check out our docs [here](https://stenciljs.com/docs/my-first-component).
 
-
 ## Naming Components
 
 When creating new component tags, we recommend _not_ using `stencil` in the component name (ex: `<stencil-datepicker>`). This is because the generated component has little to nothing to do with Stencil; it's just a web component!
 
-Instead, use a prefix that fits your company or any name for a group of related components. For example, all of the Ionic generated web components use the prefix `ion`.
-
+Instead, use a prefix that fits your company or any name for a group of related components. For example, all of the Ionic-generated web components use the prefix `ion`.
 
 ## Using this component
 
-There are three strategies we recommend for using web components built with Stencil.
+There are 2 strategies we recommend for using web components built with Stencil.
 
 The first step for all three of these strategies is to [publish to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages).
 
-### Script tag
+You can read more about these different approaches in the [Stencil docs](tbd).
 
-- Put a script tag similar to this `<script type='module' src='https://unpkg.com/my-component@0.0.1/dist/my-component.esm.js'></script>` in the head of your index.html
-- Then you can use the element anywhere in your template, JSX, html etc
+### Lazy Loading
 
-### Node Modules
-- Run `npm install my-component --save`
-- Put a script tag similar to this `<script type='module' src='node_modules/my-component/dist/my-component.esm.js'></script>` in the head of your index.html
-- Then you can use the element anywhere in your template, JSX, html etc
+If your Stencil project is built with the [`dist`](https://stenciljs.com/docs/distribution) output target, you can import a small bootstrap script that registers all components and allows you to load individual component scripts lazily.
 
-### In a stencil-starter app
-- Run `npm install my-component --save`
-- Add an import to the npm packages `import my-component;`
-- Then you can use the element anywhere in your template, JSX, html etc
+For example, given your Stencil project namespace is called `my-design-system`, to use `my-component` on any website, inject this into your HTML:
+
+```html
+<script type="module" src="https://unpkg.com/my-design-system"></script>
+<!--
+To avoid unpkg.com redirects to the actual file, you can also directly import:
+https://unpkg.com/foobar-design-system@0.0.1/dist/foobar-design-system/foobar-design-system.esm.js
+-->
+<my-component first="Stencil" last="'Don't call me a framework' JS"></my-component>
+```
+
+This will only load the necessary scripts needed to render `<my-component />`. Once more components of this package are used, they will automatically be loaded lazily.
+
+You can also import the script as part of your `node_modules` in your applications entry file:
+
+```tsx
+import 'foobar-design-system/dist/foobar-design-system/foobar-design-system.esm.js';
+```
+
+Check out this [Live Demo](https://stackblitz.com/edit/vitejs-vite-y6v26a?file=src%2Fmain.tsx).
+
+### Standalone
+
+If you are using Stencil components as part of a separate compiler that handles bundling and tree-shaking for you, we recommend importing Stencil components individually in those files where they are needed.
+
+To export Stencil components as standalone components make sure you have the [`dist-custom-elements`](https://stenciljs.com/docs/custom-elements) output target defined in your `stencil.config.ts`.
+
+For example, given you'd like to use `<my-component />` as part of a React component, you can import the component directly via:
+
+```tsx
+import { defineCustomElement } from 'foobar-design-system/dist/components/my-component.js';
+defineCustomElement();
+
+function App() {
+  return (
+    <>
+      <div>
+        <my-component
+          first="Stencil"
+          last="'Don't call me a framework' JS"
+        ></my-component>
+      </div>
+    </>
+  );
+}
+
+export default App;
+```
+
+Check out this [Live Demo](https://stackblitz.com/edit/vitejs-vite-b6zuds?file=src%2FApp.tsx).

--- a/readme.md
+++ b/readme.md
@@ -53,11 +53,11 @@ Instead, use a prefix that fits your company or any name for a group of related 
 
 ## Using this component
 
-There are 2 strategies we recommend for using web components built with Stencil.
+There are two strategies we recommend for using web components built with Stencil.
 
 The first step for all three of these strategies is to [publish to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages).
 
-You can read more about these different approaches in the [Stencil docs](tbd).
+You can read more about these different approaches in the [Stencil docs](https://stenciljs.com/docs/publishing).
 
 ### Lazy Loading
 
@@ -93,7 +93,7 @@ To export Stencil components as standalone components make sure you have the [`d
 For example, given you'd like to use `<my-component />` as part of a React component, you can import the component directly via:
 
 ```tsx
-import 'foobar-design-system/dist/components/my-component.js';
+import 'foobar-design-system/my-component';
 
 function App() {
   return (
@@ -111,4 +111,4 @@ function App() {
 export default App;
 ```
 
-Check out this [Live Demo](https://stackblitz.com/edit/vitejs-vite-b6zuds?file=src%2FApp.tsx). You can shorten the import path by providing a custom `exports` map in your `package.json`.
+Check out this [Live Demo](https://stackblitz.com/edit/vitejs-vite-b6zuds?file=src%2FApp.tsx).

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Instead, use a prefix that fits your company or any name for a group of related 
 
 There are two strategies we recommend for using web components built with Stencil.
 
-The first step for all three of these strategies is to [publish to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages).
+The first step for all two of these strategies is to [publish to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages).
 
 You can read more about these different approaches in the [Stencil docs](https://stenciljs.com/docs/publishing).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,11 @@
-export * from './components';
+/**
+ * @fileoverview entry point for your component library
+ *
+ * This is the entry point for your component library. Use this file to export utilities,
+ * constants or data structure that accompany your components.
+ *
+ * DO NOT use this file to export your components. Instead, use the recommended approaches
+ * to consume components of this package as outlined in the `README.md`.
+ */
+
+export { format } from './utils/utils';

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -9,6 +9,7 @@ export const config: Config = {
     },
     {
       type: 'dist-custom-elements',
+      customElementsExportBehavior: 'auto-define-custom-elements'
     },
     {
       type: 'docs-readme',

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -9,7 +9,8 @@ export const config: Config = {
     },
     {
       type: 'dist-custom-elements',
-      customElementsExportBehavior: 'auto-define-custom-elements'
+      customElementsExportBehavior: 'auto-define-custom-elements',
+      externalRuntime: false,
     },
     {
       type: 'docs-readme',


### PR DESCRIPTION
This patch resolves some of the confusions around starting a component design system with Stencil and consuming its components. Changes in particular:

- removed `es2015` and `es2017` as these export references aren't used anymore outside nor did they become a standardized approach to export modules
- set `customElementsExportBehavior` to `'auto-define-custom-elements'` so that importing components doesn't need a `defineCustomElement` call
- set `externalRuntime` to `false` to we can move `@stencil/core` into the dev dependency section (fixes #95)
- add documentation around the purpose of `src/index.ts`
- add documentation in the `README.md` how to distribute the component

Will keep the PR as a draft until I updated the docs on distributing components.