### PR TITLE
chore(): fix a small typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "./my-component": {
       "import": "./dist/components/my-component.js",
-      "types": "./dist/components/my-component.d.js"
+      "types": "./dist/components/my-component.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
I don't believe we'd have a `.d.js` file!