### PR TITLE
fix(types): export JSX typings from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,4 @@
  */
 
 export { format } from './utils/utils';
-export * from './components';
+export type * from './components.d.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@
  */
 
 export { format } from './utils/utils';
+export * from './components';


### PR DESCRIPTION
re-add an export statement to re-export the contents of './components/' from the root level index.ts file.

prior to this commit, folks using stencil's tutorial for spinning up a new project using our react framework wrapper would be greeted with the following error:
```
lib/components/stencil-generated/index.ts:6:15 - error TS2305: Module '"stencil-library"' has no exported member 'JSX'.

6 import type { JSX } from 'stencil-library';
                ~~~
Found 1 error in lib/components/stencil-generated/index.ts:6
```

this re-exports the type, previously removed in https://github.com/ionic-team/stencil-component-starter/pull/134