### PR TITLE
fix(exports): add explicit loader export mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "./my-component": {
       "import": "./dist/components/my-component.js",
       "types": "./dist/components/my-component.d.ts"
+    },
+    "./loader": {
+      "import": "./loader/index.js",
+      "require": "./loader/index.cjs",
+      "types": "./loader/index.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
this commit adds an export mapping to the loader package to `package.json`.

prior to this commit, users working their way through stencil's guide for setting up the react output target would run into an error when trying to spin up a react app with vite:

```
vite v5.2.9 building for production...
✓ 7 modules transformed.
x Build failed in 31ms
error during build:
Error: [commonjs--resolver] Missing "./loader" specifier in "stencil-library" package
     <STACK_TRACE_OMITTED>

npm ERR! Lifecycle script `build` failed with error:
npm ERR! Error: command failed
npm ERR!   in workspace: my-app@0.0.0
npm ERR!   at location: /private/tmp/react-set-asset-path/packages/my-app
```

this restores the behavior previously supported in https://github.com/ionic-team/stencil-component-starter/pull/134, without requiring us to rewrite the react guide