### PR TITLE
fix(types): fix format utils function type signature

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,3 @@
-export function format(first: string, middle: string, last: string): string {
+export function format(first?: string, middle?: string, last?: string): string {
   return (first || '') + (middle ? ` ${middle}` : '') + (last ? ` ${last}` : '');
 }


### PR DESCRIPTION
This PR updates the `format` function signature in `utils/` by marking its parameters as optional to match intended typings based on the unit tests and usage.

Previously, type checking would fail unless the `strict` TypeScript compiler option was set to `false`