### PR TITLE
refactor(example): Update example code to use middle name prop.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ For example, given your Stencil project namespace is called `my-design-system`, 
 To avoid unpkg.com redirects to the actual file, you can also directly import:
 https://unpkg.com/foobar-design-system@0.0.1/dist/foobar-design-system/foobar-design-system.esm.js
 -->
-<my-component first="Stencil" last="'Don't call me a framework' JS"></my-component>
+<my-component first="Stencil" middle="'Don't call me a framework'" last="JS"></my-component>
 ```
 
 This will only load the necessary scripts needed to render `<my-component />`. Once more components of this package are used, they will automatically be loaded lazily.
@@ -101,7 +101,8 @@ function App() {
       <div>
         <my-component
           first="Stencil"
-          last="'Don't call me a framework' JS"
+          middle="'Don't call me a framework'"
+          last="JS"
         ></my-component>
       </div>
     </>

--- a/src/components/my-component/my-component.spec.ts
+++ b/src/components/my-component/my-component.spec.ts
@@ -21,10 +21,10 @@ describe('my-component', () => {
   it('renders with values', async () => {
     const { root } = await newSpecPage({
       components: [MyComponent],
-      html: `<my-component first="Stencil" last="'Don't call me a framework' JS"></my-component>`,
+      html: `<my-component first="Stencil" middle="'Don't call me a framework'" last="JS"></my-component>`,
     });
     expect(root).toEqualHtml(`
-      <my-component first="Stencil" last="'Don't call me a framework' JS">
+      <my-component first="Stencil" middle="'Don't call me a framework'" last="JS">
         <mock:shadow-root>
           <div>
             Hello, World! I'm Stencil 'Don't call me a framework' JS

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,6 @@
     <script nomodule src="/build/stencil-starter-project-name.js"></script>
   </head>
   <body>
-    <my-component first="Stencil" last="'Don't call me a framework' JS"></my-component>
+    <my-component first="Stencil" middle="'Don't call me a framework'" last="JS"></my-component>
   </body>
 </html>


### PR DESCRIPTION
This pull request includes updates to the `my-component` element to use the `middle` attribute and adjust its usage across various files.

Updates to `my-component` usage:

* `readme.md`: Updated the example usage of `<my-component>` to include the `middle` attribute and adjusted the `last` attribute accordingly.
* `src/index.html`: Modified the `<my-component>` element to include the `middle` attribute.

Test updates:
* `src/components/my-component/my-component.spec.ts`: Updated the test case to include the `middle` attribute for `<my-component>`.

Closes: #139 